### PR TITLE
Task 3: Undo add and remove from reading list

### DIFF
--- a/apps/okreads-e2e/src/integration/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/integration/reading-list.spec.ts
@@ -11,4 +11,33 @@ describe('When: I use the reading list feature', () => {
       'My Reading List'
     );
   });
+
+  it('Then: I should be able to add book in my reading list', async () => {
+    cy.get('input[type="search"]').type('javascript');
+    cy.get('form').submit();
+    cy.get('[data-testing="book-item"]').should('have.length.greaterThan', 1);
+    cy.get('#wantToRead_0').click();
+    cy.get('[data-testing="toggle-reading-list"]').click();
+    cy.get('#wantToRemove_0').click();
+  });
+
+  it('Then: I should be able to view snack bar and add item', async () => {
+    cy.get('input[type="search"]').type('javascript');
+    cy.get('form').submit();
+    cy.get('[data-testing="book-item"]').should('have.length.greaterThan', 1);
+    cy.get('#wantToRead_0').click();
+    cy.get('snack-bar-container').should('contain.text', 'Added');
+    cy.get('[data-testing="toggle-reading-list"]').click();
+    cy.get('#wantToRemove_0').click();
+  });
+
+  it('Then: I should able to remove my action from snack bar', async () => {
+    cy.get('input[type="search"]').type('javascript');
+    cy.get('form').submit();
+    cy.get('[data-testing="book-item"]').should('have.length.greaterThan', 1);
+    cy.get('#wantToRead_0').click();
+    cy.get('[data-testing="toggle-reading-list"]').click();
+    cy.get('#wantToRemove_0').click();
+    cy.get('snack-bar-container').should('contain.text', 'Removed');
+  });
 });

--- a/apps/okreads-e2e/src/integration/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/integration/reading-list.spec.ts
@@ -16,28 +16,28 @@ describe('When: I use the reading list feature', () => {
     cy.get('input[type="search"]').type('javascript');
     cy.get('form').submit();
     cy.get('[data-testing="book-item"]').should('have.length.greaterThan', 1);
-    cy.get('#wantToRead_0').click();
+    cy.get('[data-testing="wantToRead_0"]').click();
     cy.get('[data-testing="toggle-reading-list"]').click();
-    cy.get('#wantToRemove_0').click();
+    cy.get('[data-testing="wantToRemove_0"]').click();
   });
 
   it('Then: I should be able to view snack bar and add item', async () => {
     cy.get('input[type="search"]').type('javascript');
     cy.get('form').submit();
     cy.get('[data-testing="book-item"]').should('have.length.greaterThan', 1);
-    cy.get('#wantToRead_0').click();
+    cy.get('[data-testing="wantToRead_0"]').click();
     cy.get('snack-bar-container').should('contain.text', 'Added');
     cy.get('[data-testing="toggle-reading-list"]').click();
-    cy.get('#wantToRemove_0').click();
+    cy.get('[data-testing="wantToRemove_0"]').click();
   });
 
   it('Then: I should able to remove my action from snack bar', async () => {
     cy.get('input[type="search"]').type('javascript');
     cy.get('form').submit();
     cy.get('[data-testing="book-item"]').should('have.length.greaterThan', 1);
-    cy.get('#wantToRead_0').click();
+    cy.get('[data-testing="wantToRead_0"]').click();
     cy.get('[data-testing="toggle-reading-list"]').click();
-    cy.get('#wantToRemove_0').click();
+    cy.get('[data-testing="wantToRemove_0"]').click();
     cy.get('snack-bar-container').should('contain.text', 'Removed');
   });
 });

--- a/libs/books/data-access/src/lib/+state/reading-list.actions.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.actions.ts
@@ -17,6 +17,11 @@ export const addToReadingList = createAction(
   props<{ book: Book }>()
 );
 
+export const UndoAddToReadingList = createAction(
+  '[Reading List API] Undo add to list',
+  props<{ book: Book }>()
+);
+
 export const failedAddToReadingList = createAction(
   '[Reading List API] Failed add to list',
   props<{ book: Book }>()
@@ -29,6 +34,11 @@ export const confirmedAddToReadingList = createAction(
 
 export const removeFromReadingList = createAction(
   '[Books Search Results] Remove from list',
+  props<{ item: ReadingListItem }>()
+);
+
+export const UndoremoveFromReadingList = createAction(
+  '[Reading List API]  Undo Remove from list',
   props<{ item: ReadingListItem }>()
 );
 

--- a/libs/books/data-access/src/lib/+state/reading-list.reducer.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.reducer.ts
@@ -18,33 +18,33 @@ export interface ReadingListPartialState {
 export const readingListAdapter: EntityAdapter<ReadingListItem> = createEntityAdapter<
   ReadingListItem
 >({
-  selectId: item => item.bookId
+  selectId: (item) => item.bookId,
 });
 
 export const initialState: State = readingListAdapter.getInitialState({
   loaded: false,
-  error: null
+  error: null,
 });
 
 const readingListReducer = createReducer(
   initialState,
-  on(ReadingListActions.init, state => {
+  on(ReadingListActions.init, (state) => {
     return {
       ...state,
       loaded: false,
-      error: null
+      error: null,
     };
   }),
   on(ReadingListActions.loadReadingListSuccess, (state, action) => {
     return readingListAdapter.setAll(action.list, {
       ...state,
-      loaded: true
+      loaded: true,
     });
   }),
   on(ReadingListActions.loadReadingListError, (state, action) => {
     return {
       ...state,
-      error: action.error
+      error: action.error,
     };
   }),
   on(ReadingListActions.addToReadingList, (state, action) =>
@@ -52,6 +52,15 @@ const readingListReducer = createReducer(
   ),
   on(ReadingListActions.removeFromReadingList, (state, action) =>
     readingListAdapter.removeOne(action.item.bookId, state)
+  ),
+  on(ReadingListActions.UndoAddToReadingList, (state, action) =>
+    readingListAdapter.removeOne(action.book.id, state)
+  ),
+  on(ReadingListActions.UndoremoveFromReadingList, (state, action) =>
+    readingListAdapter.addOne(
+      { bookId: action.item.bookId, ...action.item },
+      state
+    )
   )
 );
 

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -16,7 +16,7 @@
 
 <ng-container *ngIf="searchTerm; else empty">
   <div class="book-grid">
-    <div class="book" data-testing="book-item" *ngFor="let b of books">
+    <div class="book" data-testing="book-item" *ngFor="let b of books; let i = index">
       <div class="book--title">
         <div role="heading" aria-label="1">{{ b.title }}</div>
       </div>
@@ -33,6 +33,7 @@
           <p [innerHTML]="b.description"></p>
           <div>
             <button
+              id="{{ 'wantToRead_' + i }}"
               mat-flat-button
               color="primary"
               (click)="addBookToReadingList(b)"

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -33,7 +33,7 @@
           <p [innerHTML]="b.description"></p>
           <div>
             <button
-              id="{{ 'wantToRead_' + i }}"
+              data-testing="{{ 'wantToRead_' + i }}"
               mat-flat-button
               color="primary"
               (click)="addBookToReadingList(b)"

--- a/libs/books/feature/src/lib/book-search/book-search.component.ts
+++ b/libs/books/feature/src/lib/book-search/book-search.component.ts
@@ -5,26 +5,30 @@ import {
   clearSearch,
   getAllBooks,
   ReadingListBook,
-  searchBooks
+  searchBooks,
+  UndoAddToReadingList
 } from '@tmo/books/data-access';
 import { FormBuilder } from '@angular/forms';
 import { Book } from '@tmo/shared/models';
-
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { take } from 'rxjs/operators';
+import { GlobalConstant } from '../constants';
 @Component({
   selector: 'tmo-book-search',
   templateUrl: './book-search.component.html',
-  styleUrls: ['./book-search.component.scss']
+  styleUrls: ['./book-search.component.scss'],
 })
 export class BookSearchComponent implements OnInit {
   books: ReadingListBook[];
 
   searchForm = this.fb.group({
-    term: ''
+    term: '',
   });
 
   constructor(
     private readonly store: Store,
-    private readonly fb: FormBuilder
+    private readonly fb: FormBuilder,
+    private _snackBar: MatSnackBar
   ) {}
 
   get searchTerm(): string {
@@ -32,7 +36,7 @@ export class BookSearchComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.store.select(getAllBooks).subscribe(books => {
+    this.store.select(getAllBooks).subscribe((books) => {
       this.books = books;
     });
   }
@@ -45,6 +49,19 @@ export class BookSearchComponent implements OnInit {
 
   addBookToReadingList(book: Book) {
     this.store.dispatch(addToReadingList({ book }));
+    const snackBarRef = this._snackBar.open(
+      GlobalConstant.ADD,
+      GlobalConstant.UNDO,
+      {
+        duration: GlobalConstant.FiveThousand,
+        horizontalPosition: 'right',
+        verticalPosition: 'bottom',
+      }
+    );
+    snackBarRef
+      .onAction()
+      .pipe(take(1))
+      .subscribe(() => this.store.dispatch(UndoAddToReadingList({ book })));
   }
 
   searchExample() {

--- a/libs/books/feature/src/lib/constants.ts
+++ b/libs/books/feature/src/lib/constants.ts
@@ -1,0 +1,6 @@
+export const GlobalConstant = {
+  ADD: 'Added',
+  UNDO: 'Undo',
+  FiveThousand: 5000,
+  REMOVED: 'Removed'
+};

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="(readingList$ | async).length > 0; else empty">
-  <div class="reading-list-item" *ngFor="let b of readingList$ | async">
+  <div class="reading-list-item" *ngFor="let b of readingList$ | async; let i = index ">
     <div>
       <img
         class="reading-list-item--cover"
@@ -15,6 +15,7 @@
     </div>
     <div>
       <button
+        id="{{ 'wantToRemove_' + i }}"
         mat-icon-button
         color="warn"
         [attr.aria-label]="'Remove ' + b.title + ' from reading list'"

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -15,7 +15,7 @@
     </div>
     <div>
       <button
-        id="{{ 'wantToRemove_' + i }}"
+        data-testing="{{ 'wantToRemove_' + i }}"
         mat-icon-button
         color="warn"
         [attr.aria-label]="'Remove ' + b.title + ' from reading list'"

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.ts
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.ts
@@ -1,18 +1,35 @@
 import { Component } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { getReadingList, removeFromReadingList } from '@tmo/books/data-access';
-
+import {
+  getReadingList,
+  removeFromReadingList,
+  UndoremoveFromReadingList,
+} from '@tmo/books/data-access';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { GlobalConstant } from '../constants';
 @Component({
   selector: 'tmo-reading-list',
   templateUrl: './reading-list.component.html',
-  styleUrls: ['./reading-list.component.scss']
+  styleUrls: ['./reading-list.component.scss'],
 })
 export class ReadingListComponent {
   readingList$ = this.store.select(getReadingList);
 
-  constructor(private readonly store: Store) {}
+  constructor(private readonly store: Store, private _snackBar: MatSnackBar) {}
 
   removeFromReadingList(item) {
     this.store.dispatch(removeFromReadingList({ item }));
+    const snackBarRef = this._snackBar.open(
+      GlobalConstant.REMOVED,
+      GlobalConstant.UNDO,
+      {
+        duration: GlobalConstant.FiveThousand,
+        horizontalPosition: 'right',
+        verticalPosition: 'bottom',
+      }
+    );
+    snackBarRef.onAction().subscribe(() => {
+      this.store.dispatch(UndoremoveFromReadingList({ item }));
+    });
   }
 }


### PR DESCRIPTION
Requirements

As a user, I want to be able to quickly undo my action when clicking the Want to Read button in the book list, or the remove button in the reading list.

- [x] Starting from the chore/code-review branch from Task 1, create a new branch feat/undo-actions.
- [x] Update the code such that a snackbar appears whenever the user adds or removes a book. (Hint: this module is already installed and set up)
- [x] The snackbar must display the event that occurred (i.e. added/removed), and an Undo action.
- [x] When the user clicks Undo it should set the reading list state back to the previous state.
- [x] Write a new e2e test in apps/okreads-e2e/src/specs/reading-list.spec.ts to test the new undo feature.
- [x] Commit your changes on the feature branch and open a pull-request with chore/code-review as the target.

**npm run test**
![image](https://user-images.githubusercontent.com/6745421/127603714-df791ad2-df30-42cd-8517-15b8c87b7d9c.png)

**npm run lint**
![image](https://user-images.githubusercontent.com/6745421/127603773-8f5e5d23-75c1-48eb-b6bd-3cb70ba8d8d8.png)

**npm run e2e**
![image](https://user-images.githubusercontent.com/6745421/127603825-6fb86bf1-de70-476e-a950-50bf97c51ea4.png)

